### PR TITLE
feat: Add separate site selector for Competitive Analysis tool

### DIFF
--- a/src/components/CompetitiveAnalysisModal.tsx
+++ b/src/components/CompetitiveAnalysisModal.tsx
@@ -13,28 +13,24 @@ interface Competitor {
 }
 
 interface CompetitiveAnalysisModalProps {
-  userWebsites: Website[];
-  userCompetitors: Competitor[];
+  selectedUserWebsite: string;
+  selectedCompetitor: string;
   onClose: () => void;
   onAnalysisComplete: (results: any) => void;
+  userWebsites: Website[];
+  userCompetitors: Competitor[];
 }
 
 const CompetitiveAnalysisModal: React.FC<CompetitiveAnalysisModalProps> = ({
-  userWebsites,
-  userCompetitors,
+  selectedUserWebsite,
+  selectedCompetitor,
   onClose,
   onAnalysisComplete,
+  userWebsites,
+  userCompetitors,
 }) => {
-  const [selectedUserWebsite, setSelectedUserWebsite] = useState<string>(userWebsites[0]?.url || '');
-  const [selectedCompetitor, setSelectedCompetitor] = useState<string>(userCompetitors[0]?.url || '');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (userCompetitors.length > 0 && !selectedCompetitor) {
-      setSelectedCompetitor(userCompetitors[0].url);
-    }
-  }, [userCompetitors, selectedCompetitor]);
 
   const handleRunAnalysis = async () => {
     if (!selectedUserWebsite || !selectedCompetitor) {
@@ -82,33 +78,13 @@ const CompetitiveAnalysisModal: React.FC<CompetitiveAnalysisModalProps> = ({
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 Your Website
               </label>
-              <select
-                value={selectedUserWebsite}
-                onChange={(e) => setSelectedUserWebsite(e.target.value)}
-                className="w-full border border-gray-300 rounded-lg px-3 py-2"
-              >
-                {userWebsites.map((site) => (
-                  <option key={site.url} value={site.url}>
-                    {site.name}
-                  </option>
-                ))}
-              </select>
+              <p className="text-lg font-semibold text-gray-900">{userWebsites.find(site => site.url === selectedUserWebsite)?.name || selectedUserWebsite}</p>
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 Competitor's Website
               </label>
-              <select
-                value={selectedCompetitor}
-                onChange={(e) => setSelectedCompetitor(e.target.value)}
-                className="w-full border border-gray-300 rounded-lg px-3 py-2"
-              >
-                {userCompetitors.map((competitor) => (
-                  <option key={competitor.url} value={competitor.url}>
-                    {competitor.name}
-                  </option>
-                ))}
-              </select>
+              <p className="text-lg font-semibold text-gray-900">{userCompetitors.find(c => c.url === selectedCompetitor)?.name || selectedCompetitor}</p>
             </div>
           </div>
 

--- a/src/components/CompetitiveAnalysisSiteSelector.tsx
+++ b/src/components/CompetitiveAnalysisSiteSelector.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { ChevronDown, Target } from 'lucide-react';
+
+interface Website {
+  url: string;
+  name: string;
+}
+
+interface Competitor {
+  url: string;
+  name: string;
+}
+
+interface CompetitiveAnalysisSiteSelectorProps {
+  userWebsites: Website[];
+  competitors: Competitor[];
+  selectedUserWebsite: string;
+  selectedCompetitor: string;
+  onUserWebsiteChange: (url: string) => void;
+  onCompetitorChange: (url: string) => void;
+}
+
+const CompetitiveAnalysisSiteSelector: React.FC<CompetitiveAnalysisSiteSelectorProps> = ({
+  userWebsites,
+  competitors,
+  selectedUserWebsite,
+  selectedCompetitor,
+  onUserWebsiteChange,
+  onCompetitorChange,
+}) => {
+  return (
+    <div className="bg-white rounded-xl shadow-sm p-6 border border-gray-100">
+      <h3 className="text-lg font-semibold text-gray-900 mb-4">Competitive Analysis Setup</h3>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Your Website
+          </label>
+          <div className="relative">
+            <select
+              value={selectedUserWebsite}
+              onChange={(e) => onUserWebsiteChange(e.target.value)}
+              className="w-full appearance-none bg-white border border-gray-300 rounded-lg px-4 py-3 pr-10 focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+            >
+              {userWebsites.length === 0 ? (
+                <option value="">No websites available</option>
+              ) : (
+                userWebsites.map((website, index) => (
+                  <option key={index} value={website.url}>
+                    {website.name} ({website.url})
+                  </option>
+                ))
+              )}
+            </select>
+            <ChevronDown className="absolute right-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400 pointer-events-none" />
+          </div>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Competitor's Website
+          </label>
+          <div className="relative">
+            <select
+              value={selectedCompetitor}
+              onChange={(e) => onCompetitorChange(e.target.value)}
+              className="w-full appearance-none bg-white border border-gray-300 rounded-lg px-4 py-3 pr-10 focus:ring-2 focus:ring-red-500 focus:border-transparent"
+            >
+              {competitors.length === 0 ? (
+                <option value="">No competitors available</option>
+              ) : (
+                competitors.map((competitor, index) => (
+                  <option key={index} value={competitor.url}>
+                    {competitor.name} ({competitor.url})
+                  </option>
+                ))
+              )}
+            </select>
+            <Target className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400 pointer-events-none" />
+            <ChevronDown className="absolute right-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400 pointer-events-none" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CompetitiveAnalysisSiteSelector;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -12,6 +12,7 @@ import OptimizationPlaybooks from './OptimizationPlaybooks';
 import ChatbotPopup from './ChatbotPopup';
 import DashboardWalkthrough from './DashboardWalkthrough';
 import SiteSelector from './SiteSelector';
+import CompetitiveAnalysisSiteSelector from './CompetitiveAnalysisSiteSelector';
 import SettingsModal from './SettingsModal';
 import BillingModal from './BillingModal';
 import FeedbackModal from './FeedbackModal';
@@ -51,6 +52,7 @@ const Dashboard: React.FC<DashboardProps> = ({ userPlan, onNavigateToLanding, us
   const [hasRunTools, setHasRunTools] = useState(false);
   const [selectedTool, setSelectedTool] = useState<string | null>(null);
   const [selectedWebsite, setSelectedWebsite] = useState<string>('');
+  const [selectedCompetitor, setSelectedCompetitor] = useState<string>('');
   const [loading, setLoading] = useState(false);
   const [loadingProfile, setLoadingProfile] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
@@ -383,7 +385,10 @@ const Dashboard: React.FC<DashboardProps> = ({ userPlan, onNavigateToLanding, us
     if (userProfile && userProfile.websites && userProfile.websites.length > 0 && !selectedWebsite) {
       setSelectedWebsite(userProfile.websites[0].url);
     }
-  }, [userProfile, selectedWebsite]);
+    if (userProfile && userProfile.competitors && userProfile.competitors.length > 0 && !selectedCompetitor) {
+      setSelectedCompetitor(userProfile.competitors[0].url);
+    }
+  }, [userProfile, selectedWebsite, selectedCompetitor]);
 
   // Generate insights when profile loads - only once
   useEffect(() => {
@@ -649,13 +654,24 @@ const Dashboard: React.FC<DashboardProps> = ({ userPlan, onNavigateToLanding, us
 
             {/* Site Selector - Show if user has completed onboarding */}
             {userProfile && userProfile.websites && userProfile.websites.length > 0 && (
-              <SiteSelector
-                websites={userProfile.websites}
-                competitors={userProfile.competitors || []}
-                selectedWebsite={selectedWebsite}
-                onWebsiteChange={setSelectedWebsite}
-                userPlan={userPlan}
-              />
+              activeSection === 'competitive-viz' ? (
+                <CompetitiveAnalysisSiteSelector
+                  userWebsites={userProfile.websites}
+                  competitors={userProfile.competitors || []}
+                  selectedUserWebsite={selectedWebsite}
+                  selectedCompetitor={selectedCompetitor}
+                  onUserWebsiteChange={setSelectedWebsite}
+                  onCompetitorChange={setSelectedCompetitor}
+                />
+              ) : (
+                <SiteSelector
+                  websites={userProfile.websites}
+                  competitors={userProfile.competitors || []}
+                  selectedWebsite={selectedWebsite}
+                  onWebsiteChange={setSelectedWebsite}
+                  userPlan={userPlan}
+                />
+              )
             )}
 
             {/* Goal Tracker */}


### PR DESCRIPTION
This commit introduces a new site selector component specifically for the Competitive Analysis tool. This allows you to select both your own website and a competitor's website for comparison, independent of the global site selector.

- Created a new `CompetitiveAnalysisSiteSelector.tsx` component with dropdowns for user and competitor websites.
- Updated the `Dashboard.tsx` component to conditionally render the new selector when the Competitive Analysis tool is active.
- Removed the redundant dropdown selectors from the `CompetitiveAnalysisModal.tsx` component, which now receives the selected sites as props.