### PR TITLE
fix: Use per-function deno.json for shared module imports

### DIFF
--- a/supabase/functions/adaptive-playbook-generator/deno.json
+++ b/supabase/functions/adaptive-playbook-generator/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/adaptive-playbook-generator/index.ts
+++ b/supabase/functions/adaptive-playbook-generator/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { adaptivePlaybookGeneratorHandler } from "./adaptivePlaybookGeneratorHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/ai-content-generator/deno.json
+++ b/supabase/functions/ai-content-generator/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/ai-content-generator/index.ts
+++ b/supabase/functions/ai-content-generator/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { aiContentGeneratorHandler } from "./aiContentGeneratorHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/ai-visibility-audit/deno.json
+++ b/supabase/functions/ai-visibility-audit/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/ai-visibility-audit/index.ts
+++ b/supabase/functions/ai-visibility-audit/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { aiVisibilityAuditHandler } from "./aiVisibilityAuditHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/anomaly-detection/deno.json
+++ b/supabase/functions/anomaly-detection/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/anomaly-detection/index.ts
+++ b/supabase/functions/anomaly-detection/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { anomalyDetectionHandler } from "./anomalyDetectionHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/citation-tracker/deno.json
+++ b/supabase/functions/citation-tracker/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/citation-tracker/index.ts
+++ b/supabase/functions/citation-tracker/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { citationTrackerHandler } from "./citationTrackerHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/competitive-analysis/deno.json
+++ b/supabase/functions/competitive-analysis/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/competitive-analysis/index.ts
+++ b/supabase/functions/competitive-analysis/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { competitiveAnalysisHandler } from "./competitiveAnalysisHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/competitor-discovery/deno.json
+++ b/supabase/functions/competitor-discovery/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/competitor-discovery/index.ts
+++ b/supabase/functions/competitor-discovery/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { competitorDiscoveryHandler } from "./competitorDiscoveryHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/content-optimizer/deno.json
+++ b/supabase/functions/content-optimizer/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/content-optimizer/index.ts
+++ b/supabase/functions/content-optimizer/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { contentOptimizerHandler } from "./contentOptimizerHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/create-checkout/deno.json
+++ b/supabase/functions/create-checkout/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/create-checkout/index.ts
+++ b/supabase/functions/create-checkout/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { createCheckoutHandler } from "./createCheckoutHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/enhanced-audit-insights/deno.json
+++ b/supabase/functions/enhanced-audit-insights/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/enhanced-audit-insights/index.ts
+++ b/supabase/functions/enhanced-audit-insights/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { enhancedAuditInsightsHandler } from "./enhancedAuditInsightsHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/enhanced-report-generation/deno.json
+++ b/supabase/functions/enhanced-report-generation/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/enhanced-report-generation/index.ts
+++ b/supabase/functions/enhanced-report-generation/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { enhancedReportGenerationHandler } from "./enhancedReportGenerationHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/entity-coverage-analyzer/deno.json
+++ b/supabase/functions/entity-coverage-analyzer/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/entity-coverage-analyzer/index.ts
+++ b/supabase/functions/entity-coverage-analyzer/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { entityCoverageAnalyzerHandler } from "./entityCoverageAnalyzerHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/generate-report/deno.json
+++ b/supabase/functions/generate-report/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/generate-report/index.ts
+++ b/supabase/functions/generate-report/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { generateReportHandler } from "./generateReportHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/genie-chatbot/deno.json
+++ b/supabase/functions/genie-chatbot/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/genie-chatbot/index.ts
+++ b/supabase/functions/genie-chatbot/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { corsHeaders } from "../_shared/cors.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { genieChatbotHandler } from "./genieChatbotHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/import_map.json
+++ b/supabase/functions/import_map.json
@@ -1,6 +1,0 @@
-{
-  "imports": {
-    "shared/": "./_shared/",
-    "utils/": "../utils/"
-  }
-}

--- a/supabase/functions/lemonsqueezy-webhook/deno.json
+++ b/supabase/functions/lemonsqueezy-webhook/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/lemonsqueezy-webhook/index.ts
+++ b/supabase/functions/lemonsqueezy-webhook/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { corsHeaders } from "../_shared/cors.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { lemonsqueezyWebhookHandler } from "./lemonsqueezyWebhookHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/llm-site-summaries/deno.json
+++ b/supabase/functions/llm-site-summaries/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/llm-site-summaries/index.ts
+++ b/supabase/functions/llm-site-summaries/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { llmSiteSummariesHandler } from "./llmSiteSummariesHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/prompt-match-suggestions/deno.json
+++ b/supabase/functions/prompt-match-suggestions/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/prompt-match-suggestions/index.ts
+++ b/supabase/functions/prompt-match-suggestions/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { promptMatchSuggestionsHandler } from "./promptMatchSuggestionsHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/real-time-content-analysis/deno.json
+++ b/supabase/functions/real-time-content-analysis/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/real-time-content-analysis/index.ts
+++ b/supabase/functions/real-time-content-analysis/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { realTimeContentAnalysisHandler } from "./realTimeContentAnalysisHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/report-viewer/deno.json
+++ b/supabase/functions/report-viewer/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/report-viewer/index.ts
+++ b/supabase/functions/report-viewer/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { corsHeaders } from "../_shared/cors.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { reportViewerHandler } from "./reportViewerHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/run-schedule/deno.json
+++ b/supabase/functions/run-schedule/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/schema-generator/deno.json
+++ b/supabase/functions/schema-generator/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/schema-generator/index.ts
+++ b/supabase/functions/schema-generator/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { schemaGeneratorHandler } from "./schemaGeneratorHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/shopify-integration/deno.json
+++ b/supabase/functions/shopify-integration/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/shopify-integration/index.ts
+++ b/supabase/functions/shopify-integration/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { corsHeaders } from "../_shared/cors.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { shopifyIntegrationHandler } from "./shopifyIntegrationHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/voice-assistant-tester/deno.json
+++ b/supabase/functions/voice-assistant-tester/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/voice-assistant-tester/index.ts
+++ b/supabase/functions/voice-assistant-tester/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun } from "../_shared/logToolRun.ts";
-import { updateToolRun } from "../_shared/updateToolRun.ts";
-import { corsHeaders } from "../_shared/cors.ts";
+import { logToolRun } from "shared/logToolRun.ts";
+import { updateToolRun } from "shared/updateToolRun.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { voiceAssistantTesterHandler } from "./voiceAssistantTesterHandler.ts";
 
 const supabase = createClient(

--- a/supabase/functions/wordpress-integration/deno.json
+++ b/supabase/functions/wordpress-integration/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "shared/": "../_shared/"
+  }
+}

--- a/supabase/functions/wordpress-integration/index.ts
+++ b/supabase/functions/wordpress-integration/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { corsHeaders } from "../_shared/cors.ts";
+import { corsHeaders } from "shared/cors.ts";
 import { wordpressIntegrationHandler } from "./wordpressIntegrationHandler.ts";
 
 const supabase = createClient(


### PR DESCRIPTION
Resolves a "Module not found" deployment error for all edge functions.

The previous import strategy used a single, global `import_map.json`, which is not supported by the Supabase deployment environment.

This commit replaces that with the officially recommended approach:
- A `deno.json` file is added to each of the 24 function directories.
- Each `deno.json` contains an import map aliasing `shared/` to the correct relative path (`../_shared/`).
- All imports in the function wrappers (`index.ts`) have been updated to use the `shared/` alias.
- The old global `import_map.json` has been deleted.

This ensures that shared dependencies are correctly resolved during deployment for all functions.