### PR TITLE
fix: Remove selectedWebsite from useEffect dependency array

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -397,7 +397,7 @@ const Dashboard: React.FC<DashboardProps> = ({ userPlan, onNavigateToLanding, us
     if (userProfile && userProfile.competitors && userProfile.competitors.length > 0 && !selectedCompetitor) {
       setSelectedCompetitor(userProfile.competitors[0].url);
     }
-  }, [userProfile, selectedWebsite, selectedCompetitor]);
+  }, [userProfile, selectedCompetitor]);
 
   // Generate insights when profile loads - only once
   useEffect(() => {


### PR DESCRIPTION
This commit removes `selectedWebsite` from the dependency array of a `useEffect` hook in `Dashboard.tsx`.

The previous implementation caused an infinite re-render loop because the effect was both dependent on and responsible for setting the `selectedWebsite` state. This prevented the component from initializing correctly, which caused downstream issues like disabled buttons in child components.

This change breaks the dependency cycle and should allow the component to render correctly.