### PR TITLE
Fix: Use explicit relative path for global import map

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,7 +1,7 @@
 # Supabase project configuration
 
 [functions]
-  import_map = "import_map.json"
+  import_map = "./import_map.json"
 
 # The per-function import_map settings are now removed.
 # The global setting above will apply to all functions.


### PR DESCRIPTION
This commit corrects the path to the global `import_map.json` in the `config.toml` file. The previous path was missing the explicit `./` prefix, which may have caused the Supabase build process to not locate and apply the import map, leading to a deployment failure.

This change makes the path unambiguous and aligns with official Supabase examples.