### PR TITLE
fix: Correct module import paths for shared logging

### DIFF
--- a/supabase/functions/adaptive-playbook-generator/index.ts
+++ b/supabase/functions/adaptive-playbook-generator/index.ts
@@ -1,5 +1,5 @@
 import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun, updateToolRun } from "../_shared/logging.ts";
+import { logToolRun, updateToolRun } from "shared/logging.ts";
 
 // --- CORS Headers ---
 const corsHeaders = {

--- a/supabase/functions/ai-content-generator/index.ts
+++ b/supabase/functions/ai-content-generator/index.ts
@@ -1,5 +1,5 @@
 import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun, updateToolRun } from "../_shared/logging.ts";
+import { logToolRun, updateToolRun } from "shared/logging.ts";
 
 // --- CORS Headers ---
 const corsHeaders = {

--- a/supabase/functions/anomaly-detection/index.ts
+++ b/supabase/functions/anomaly-detection/index.ts
@@ -1,5 +1,5 @@
 import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun, updateToolRun } from '../_shared/logging.ts';
+import { logToolRun, updateToolRun } from 'shared/logging.ts';
 
 // --- CORS Headers ---
 const corsHeaders = {

--- a/supabase/functions/citation-tracker/index.ts
+++ b/supabase/functions/citation-tracker/index.ts
@@ -1,5 +1,5 @@
 import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun, updateToolRun } from '../_shared/logging.ts';
+import { logToolRun, updateToolRun } from 'shared/logging.ts';
 
 // --- CORS Headers ---
 const corsHeaders = {

--- a/supabase/functions/competitive-analysis/index.ts
+++ b/supabase/functions/competitive-analysis/index.ts
@@ -1,5 +1,5 @@
 import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun, updateToolRun } from '../_shared/logging.ts';
+import { logToolRun, updateToolRun } from 'shared/logging.ts';
 
 // --- CORS Headers ---
 const corsHeaders = {

--- a/supabase/functions/competitor-discovery/index.ts
+++ b/supabase/functions/competitor-discovery/index.ts
@@ -1,6 +1,6 @@
 import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { createHmac } from "https://deno.land/std@0.224.0/node/crypto.ts";
-import { logToolRun, updateToolRun } from "../_shared/logging.ts";
+import { logToolRun, updateToolRun } from "shared/logging.ts";
 
 // --- CORS Headers ---
 const corsHeaders = {

--- a/supabase/functions/content-optimizer/index.ts
+++ b/supabase/functions/content-optimizer/index.ts
@@ -1,5 +1,5 @@
 import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun, updateToolRun } from '../_shared/logging.ts';
+import { logToolRun, updateToolRun } from 'shared/logging.ts';
 
 // --- CORS Headers ---
 const corsHeaders = {

--- a/supabase/functions/enhanced-audit-insights/index.ts
+++ b/supabase/functions/enhanced-audit-insights/index.ts
@@ -1,5 +1,5 @@
 import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun, updateToolRun } from '../_shared/logging.ts';
+import { logToolRun, updateToolRun } from 'shared/logging.ts';
 
 // --- CORS Headers ---
 const corsHeaders = {

--- a/supabase/functions/enhanced-report-generation/index.ts
+++ b/supabase/functions/enhanced-report-generation/index.ts
@@ -1,5 +1,5 @@
 import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun, updateToolRun } from '../_shared/logging.ts';
+import { logToolRun, updateToolRun } from 'shared/logging.ts';
 
 // --- CORS Headers ---
 const corsHeaders = {

--- a/supabase/functions/entity-coverage-analyzer/index.ts
+++ b/supabase/functions/entity-coverage-analyzer/index.ts
@@ -1,5 +1,5 @@
 import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun, updateToolRun } from '../_shared/logging.ts';
+import { logToolRun, updateToolRun } from 'shared/logging.ts';
 
 // --- CORS Headers ---
 const corsHeaders = {

--- a/supabase/functions/genie-chatbot/index.ts
+++ b/supabase/functions/genie-chatbot/index.ts
@@ -1,5 +1,5 @@
 import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun, updateToolRun } from "../_shared/logging.ts";
+import { logToolRun, updateToolRun } from "shared/logging.ts";
 
 // --- CORS Headers ---
 const corsHeaders = {

--- a/supabase/functions/llm-site-summaries/index.ts
+++ b/supabase/functions/llm-site-summaries/index.ts
@@ -1,5 +1,5 @@
 import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun, updateToolRun } from "../_shared/logging.ts";
+import { logToolRun, updateToolRun } from "shared/logging.ts";
 
 // --- CORS Headers ---
 const corsHeaders = {

--- a/supabase/functions/prompt-match-suggestions/index.ts
+++ b/supabase/functions/prompt-match-suggestions/index.ts
@@ -1,5 +1,5 @@
 import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { logToolRun, updateToolRun } from '../_shared/logging.ts';
+import { logToolRun, updateToolRun } from 'shared/logging.ts';
 
 // --- CORS Headers ---
 const corsHeaders = {

--- a/supabase/functions/real-time-content-analysis/index.ts
+++ b/supabase/functions/real-time-content-analysis/index.ts
@@ -1,5 +1,5 @@
 import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { updateToolRun } from "../_shared/logging.ts"; // Only importing updateToolRun for error logging
+import { logToolRun, updateToolRun } from "shared/logging.ts"; // Only importing updateToolRun for error logging
 
 // --- CORS Headers ---
 const corsHeaders = {


### PR DESCRIPTION
This commit fixes a deployment error caused by incorrect module import paths.

The previous implementation used relative paths (`../_shared/logging.ts`) to import the shared logging module. This approach fails in the Supabase deployment environment where each function is an isolated unit.

This has been corrected by updating all refactored functions to use the `shared/logging.ts` alias defined in `supabase/import_map.json`. This ensures that the shared module can be correctly resolved during deployment.

This change affects all the previously refactored AI tools.