### PR TITLE
Enhance 'Fix it' button to support multiple SEO tool actions, add Fixes Playlist walkthrough, enable quick publish from Content Editor, and add success toasts on tool switch

### DIFF
--- a/src/components/ContentEditor.tsx
+++ b/src/components/ContentEditor.tsx
@@ -8,6 +8,7 @@ import CMSContentModal from './CMSContentModal';
 interface ContentEditorProps {
   userPlan: 'free' | 'core' | 'pro' | 'agency';
   context?: { url?: string; content?: string; title?: string; keywords?: string; contentType?: 'article' | 'product' | 'faq' | 'meta' };
+  onToast?: (toast: { type: 'success' | 'error' | 'info' | 'warning'; title: string; message?: string; duration?: number }) => void;
 }
 
 interface ContentAnalysis {
@@ -34,7 +35,7 @@ interface RealTimeSuggestion {
 
 type Integration = { id: string; cms_type: 'wordpress' | 'shopify'; cms_name: string; site_url: string };
 
-const ContentEditor: React.FC<ContentEditorProps> = ({ userPlan, context }) => {
+const ContentEditor: React.FC<ContentEditorProps> = ({ userPlan, context, onToast }) => {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [isLoadingUrl, setIsLoadingUrl] = useState(false);
@@ -58,6 +59,8 @@ const ContentEditor: React.FC<ContentEditorProps> = ({ userPlan, context }) => {
   const [loadedCmsContent, setLoadedCmsContent] = useState<{ id: any; cmsType: 'wordpress' | 'shopify'; title: string } | null>(null);
   const [isPushing, setIsPushing] = useState(false);
   const [autoGenerateSchema, setAutoGenerateSchema] = useState(true);
+  const [defaultPublishTarget, setDefaultPublishTarget] = useState<'wordpress' | 'shopify' | 'none'>('none');
+  const [publishMenuOpen, setPublishMenuOpen] = useState(false);
 
   // Fetch integrations on mount
   useEffect(() => {
@@ -65,6 +68,23 @@ const ContentEditor: React.FC<ContentEditorProps> = ({ userPlan, context }) => {
       try {
         const integrations = await apiService.getConnectedIntegrations();
         setConnectedIntegrations(integrations);
+        // Set default publish target based on last-used and available integrations
+        try {
+          const { data: { user } } = await supabase.auth.getUser();
+          const hasWP = integrations.some((i: any) => i.cms_type === 'wordpress');
+          const hasShop = integrations.some((i: any) => i.cms_type === 'shopify');
+          if (user && hasWP && hasShop) {
+            const last = await userDataService.getLastCmsTarget(user.id);
+            if (last) setDefaultPublishTarget(last);
+            else setDefaultPublishTarget('wordpress');
+          } else if (hasWP) {
+            setDefaultPublishTarget('wordpress');
+          } else if (hasShop) {
+            setDefaultPublishTarget('shopify');
+          } else {
+            setDefaultPublishTarget('none');
+          }
+        } catch {}
       } catch (error) {
         console.error("Failed to fetch connected integrations:", error);
       }
@@ -209,20 +229,31 @@ const ContentEditor: React.FC<ContentEditorProps> = ({ userPlan, context }) => {
   // Quick publish without loading an existing CMS item
   const handleQuickPublish = async (cmsType: 'wordpress' | 'shopify') => {
     if (!title.trim() || !content.trim()) {
-      alert('Please add a title and content before publishing.');
+      onToast?.({ type: 'warning', title: 'Cannot publish', message: 'Please add a title and content before publishing.', duration: 5000 });
       return;
     }
     setIsPushing(true);
     try {
+      let result: any;
       if (cmsType === 'wordpress') {
-        await apiService.publishToWordPress({ title, content, status: 'draft', autoGenerateSchema });
+        result = await apiService.publishToWordPress({ title, content, status: 'draft', autoGenerateSchema });
       } else {
-        await apiService.publishToShopify({ product: { title, body_html: content }, autoGenerateSchema });
+        result = await apiService.publishToShopify({ product: { title, body_html: content }, autoGenerateSchema });
       }
-      alert(`Published draft to ${cmsType === 'wordpress' ? 'WordPress' : 'Shopify'}!`);
-    } catch (e) {
+      const maybeUrl = result?.data?.url || result?.data?.permalink || result?.data?.product_url || result?.data?.admin_url;
+      onToast?.({
+        type: 'success',
+        title: `Published to ${cmsType === 'wordpress' ? 'WordPress' : 'Shopify'}`,
+        message: maybeUrl ? `Draft created. View: ${maybeUrl}` : 'Draft created successfully.',
+        duration: 4000
+      });
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (user) await userDataService.saveLastCmsTarget(user.id, cmsType);
+      } catch {}
+    } catch (e: any) {
       console.error('Quick publish failed:', e);
-      alert('Failed to publish draft. Please check your integration.');
+      onToast?.({ type: 'error', title: 'Publish failed', message: e?.message || 'Failed to publish draft. Please check your integration.', duration: 7000 });
     } finally {
       setIsPushing(false);
     }
@@ -362,9 +393,55 @@ const ContentEditor: React.FC<ContentEditorProps> = ({ userPlan, context }) => {
               <span>Load from {int.cms_type === 'wordpress' ? 'WordPress' : 'Shopify'}</span>
             </button>
           ))}
-          {connectedIntegrations.length > 0 && (
-            <div className="flex items-center space-x-2">
-              {connectedIntegrations.some(ci => ci.cms_type === 'wordpress') && (
+          {connectedIntegrations.length > 0 && (() => {
+            const hasWP = connectedIntegrations.some(ci => ci.cms_type === 'wordpress');
+            const hasShop = connectedIntegrations.some(ci => ci.cms_type === 'shopify');
+            if (hasWP && hasShop) {
+              const label = defaultPublishTarget === 'shopify' ? 'Shopify' : 'WordPress';
+              const primaryColor = defaultPublishTarget === 'shopify' ? 'bg-green-600 hover:bg-green-700' : 'bg-blue-600 hover:bg-blue-700';
+              return (
+                <div className="relative flex items-center">
+                  <button
+                    onClick={() => handleQuickPublish(defaultPublishTarget === 'none' ? 'wordpress' : defaultPublishTarget)}
+                    disabled={isPushing || !content.trim()}
+                    className={`${primaryColor} text-white px-3 py-2 rounded-l-lg font-medium disabled:opacity-50 flex items-center space-x-2`}
+                  >
+                    {isPushing ? <RefreshCw className="w-4 h-4 animate-spin" /> : <UploadCloud className="w-4 h-4" />}
+                    <span>Publish to {label}</span>
+                  </button>
+                  <button
+                    onClick={() => setPublishMenuOpen(v => !v)}
+                    className={`${primaryColor} text-white px-2 py-2 rounded-r-lg border-l border-white/20`}
+                  >
+                    <ChevronsUpDown className="w-4 h-4" />
+                  </button>
+                  {publishMenuOpen && (
+                    <div className="absolute right-0 top-full mt-1 w-44 bg-white border border-gray-200 rounded-md shadow-lg z-10">
+                      <button
+                        onClick={async () => {
+                          setPublishMenuOpen(false);
+                          setDefaultPublishTarget('wordpress');
+                          try { const { data: { user } } = await supabase.auth.getUser(); if (user) await userDataService.saveLastCmsTarget(user.id, 'wordpress'); } catch {}
+                          handleQuickPublish('wordpress');
+                        }}
+                        className="block w-full text-left px-3 py-2 text-sm hover:bg-gray-50"
+                      >Publish to WordPress</button>
+                      <button
+                        onClick={async () => {
+                          setPublishMenuOpen(false);
+                          setDefaultPublishTarget('shopify');
+                          try { const { data: { user } } = await supabase.auth.getUser(); if (user) await userDataService.saveLastCmsTarget(user.id, 'shopify'); } catch {}
+                          handleQuickPublish('shopify');
+                        }}
+                        className="block w-full text-left px-3 py-2 text-sm hover:bg-gray-50"
+                      >Publish to Shopify</button>
+                    </div>
+                  )}
+                </div>
+              );
+            }
+            if (hasWP) {
+              return (
                 <button
                   onClick={() => handleQuickPublish('wordpress')}
                   disabled={isPushing || !content.trim()}
@@ -373,8 +450,10 @@ const ContentEditor: React.FC<ContentEditorProps> = ({ userPlan, context }) => {
                   {isPushing ? <RefreshCw className="w-4 h-4 animate-spin" /> : <UploadCloud className="w-4 h-4" />}
                   <span>Publish to WordPress</span>
                 </button>
-              )}
-              {connectedIntegrations.some(ci => ci.cms_type === 'shopify') && (
+              );
+            }
+            if (hasShop) {
+              return (
                 <button
                   onClick={() => handleQuickPublish('shopify')}
                   disabled={isPushing || !content.trim()}
@@ -383,9 +462,10 @@ const ContentEditor: React.FC<ContentEditorProps> = ({ userPlan, context }) => {
                   {isPushing ? <RefreshCw className="w-4 h-4 animate-spin" /> : <UploadCloud className="w-4 h-4" />}
                   <span>Publish to Shopify</span>
                 </button>
-              )}
-            </div>
-          )}
+              );
+            }
+            return null;
+          })()}
           <button
             onClick={optimizeContent}
             disabled={isOptimizing || !content.trim()}

--- a/src/components/ContentEditor.tsx
+++ b/src/components/ContentEditor.tsx
@@ -7,7 +7,7 @@ import CMSContentModal from './CMSContentModal';
 
 interface ContentEditorProps {
   userPlan: 'free' | 'core' | 'pro' | 'agency';
-  context?: { url?: string };
+  context?: { url?: string; content?: string; title?: string; keywords?: string; contentType?: 'article' | 'product' | 'faq' | 'meta' };
 }
 
 interface ContentAnalysis {
@@ -73,6 +73,16 @@ const ContentEditor: React.FC<ContentEditorProps> = ({ userPlan, context }) => {
   }, []);
 
   useEffect(() => {
+    // Load direct content if provided via context (e.g., from Generator)
+    if (context?.content) {
+      setLoadedCmsContent(null);
+      setTitle(context.title || 'Generated Content');
+      setContent(context.content);
+      if (context.keywords) setTargetKeywords(context.keywords);
+      if (context.contentType) setContentType(context.contentType);
+      return; // Prefer direct content over URL fetch
+    }
+
     if (context?.url) {
       const loadContentFromUrl = async () => {
         setIsLoadingUrl(true);

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -654,7 +654,7 @@ const Dashboard: React.FC<DashboardProps> = ({
         return <ReportGenerator userPlan={effectivePlan} />;
       
       case 'editor':
-        return <ContentEditor userPlan={effectivePlan} context={toolContext} />;
+        return <ContentEditor userPlan={effectivePlan} context={toolContext} onToast={addToast} />;
       
       case 'competitive-viz':
         return <CompetitiveVisualization userPlan={effectivePlan} />;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -451,6 +451,29 @@ const Dashboard: React.FC<DashboardProps> = ({
   const handleSwitchTool = (toolId: string, context: any) => {
     setToolContext(context);
     setActiveSection(toolId);
+
+    // Success toast when tool opened from a workflow (e.g., Fix it / Generator)
+    if (context && (context.source === 'fixit' || context.source === 'generator-open-in-editor')) {
+      const toolNames: Record<string, string> = {
+        editor: 'Content Editor',
+        schema: 'Schema Generator',
+        entities: 'Entity Analyzer',
+        citations: 'Citation Tracker',
+        voice: 'Voice Assistant Tester',
+        prompts: 'Prompt Suggestions',
+        generator: 'AI Content Generator',
+        audit: 'AI Visibility Audit'
+      };
+      const pretty = toolNames[toolId] || 'Tool';
+      addToast({
+        id: `nav-${Date.now()}`,
+        type: 'success',
+        title: `Opened ${pretty}`,
+        message: context.source === 'fixit' ? 'Jumped from a recommendation to take action.' : 'Loaded generated content into the editor.',
+        duration: 3500,
+        onClose: () => {}
+      });
+    }
   };
 
   // Handle tool run from ToolsGrid - this can either open modal or navigate

--- a/src/services/userDataService.ts
+++ b/src/services/userDataService.ts
@@ -862,6 +862,54 @@ export const userDataService = {
     }
   },
 
+  // Persist simple per-website Fixes Playlist progress using user_activity to avoid new tables
+  async saveFixesPlaylistProgress(params: { userId: string; websiteUrl: string; index: number; total: number; note?: string }): Promise<void> {
+    const { userId, websiteUrl, index, total, note } = params;
+    if (!userId || !websiteUrl) {
+      console.error('saveFixesPlaylistProgress called with empty userId or websiteUrl');
+      return;
+    }
+    try {
+      await supabase.from('user_activity').insert({
+        user_id: userId,
+        activity_type: 'fixes_playlist_progress',
+        website_url: websiteUrl,
+        activity_data: { index, total, note },
+        created_at: new Date().toISOString()
+      });
+    } catch (e) {
+      console.warn('Failed to save Fixes Playlist progress:', e);
+    }
+  },
+
+  async getFixesPlaylistProgress(userId: string, websiteUrl: string): Promise<{ index: number; total?: number } | null> {
+    if (!userId || !websiteUrl) {
+      console.error('getFixesPlaylistProgress called with empty userId or websiteUrl');
+      return null;
+    }
+    try {
+      const { data, error } = await supabase
+        .from('user_activity')
+        .select('activity_data, created_at')
+        .eq('user_id', userId)
+        .eq('activity_type', 'fixes_playlist_progress')
+        .eq('website_url', websiteUrl)
+        .order('created_at', { ascending: false })
+        .limit(1);
+      if (error) throw error;
+      if (data && data.length > 0) {
+        const ad = data[0].activity_data || {};
+        if (typeof ad.index === 'number') {
+          return { index: ad.index, total: ad.total };
+        }
+      }
+      return null;
+    } catch (e) {
+      console.warn('Failed to fetch Fixes Playlist progress:', e);
+      return null;
+    }
+  },
+
   async saveReport(report: Partial<Report>): Promise<Report | null> {
     if (!report.user_id) {
       console.error('saveReport called with empty user_id');


### PR DESCRIPTION
## Summary
- Expanded the functionality of the "Fix it" button in the ToolsGrid component to handle various SEO-related actions beyond just content optimization.
- Added logic to route users to appropriate tools based on the recommendation's action type or description, including editor, schema, entities, citations, voice, prompts, and content generator.
- Improved context setting for content generation tools to better reflect the recommendation details.
- Introduced a lightweight "Fixes Playlist" walkthrough to navigate through recommendations step-by-step with controls to move between them and trigger actions.
- Added an "Open in Editor" call-to-action in the content generator results to load generated content directly into the editor with appropriate context.
- Enhanced ContentEditor to accept direct content, title, keywords, and content type via context for loading generated content directly.
- Added quick publish buttons in ContentEditor for WordPress and Shopify integrations to publish drafts directly.
- Added success toast notifications in Dashboard when switching tools from a workflow source like "fixit" or "generator-open-in-editor".

## Changes

### ToolsGrid Component
- Refactored `handleFixItClick` to analyze the recommendation's action type and description text to determine the correct tool to open.
- Added support for multiple SEO tools:
  - Content optimization/editor
  - Schema/structured data
  - Entity coverage
  - Citations/mentions
  - Voice/conversational
  - Prompts
  - Content generator (FAQs, snippets, etc.)
- Updated the default behavior to open the editor tool if no specific action matches.
- Modified the rendering logic to always show the "Fix it" button for all recommendations, not just content optimizer types.
- Added a "Fixes Playlist" UI to step through recommendations with Previous, Do it now, and Next buttons.
- Persisted Fixes Playlist progress per user and website using user activity service.

### ContentEditor Component
- Enhanced to accept direct content, title, keywords, and content type via context for loading generated content directly.
- Added quick publish buttons for WordPress and Shopify to publish drafts directly from the editor.
- Added validation and feedback for quick publish actions.
- Remember last-used CMS publish target and allow switching between WordPress and Shopify when both integrations are connected.

### Dashboard Component
- Added success toast notifications when switching tools from a workflow source like "fixit" or "generator-open-in-editor".

### ToolResultsDisplay Component
- Added "Fixes Playlist" UI for sequentially navigating recommendations.
- Added "Open in Editor" button in content generator results to load generated content into the editor with context.

### userDataService
- Added methods to save and retrieve Fixes Playlist progress per user and website.
- Added methods to save and retrieve last-used CMS publish target.

## Test plan
- [x] Verify that clicking "Fix it" on different recommendation types opens the correct tool.
- [x] Confirm that context parameters (e.g., URL, topic, content type) are passed correctly to each tool.
- [x] Ensure the default fallback to the editor tool works when no specific action is detected.
- [x] Check UI consistency with the updated button rendering logic.
- [x] Test the Fixes Playlist navigation and action buttons.
- [x] Verify the "Open in Editor" button loads generated content correctly into the editor.
- [x] Test quick publish buttons in ContentEditor for WordPress and Shopify integrations.
- [x] Confirm success toasts appear when switching tools from workflow sources.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/03c40cd8-4706-4578-867d-2769bbed5fdb
