### PR TITLE
Enhance ContentEditor with URL Loading and CMS Quick Load Buttons

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -50,4 +50,5 @@
   import_map = "./functions/wordpress-integration/deno.json"
 
 [functions.prerender-fetch]
-  # No import map required for simple fetch-only function
+  # Allow unauthenticated browser calls
+  verify_jwt = false


### PR DESCRIPTION
## Summary
- Adds URL input and fetch buttons to ContentEditor for loading page content directly
- Introduces quick load buttons for WordPress and Shopify CMS integrations
- Supports both standard URL fetch and prerendered fetch for JS-heavy pages
- Updates Supabase config to allow unauthenticated calls for prerender fetch function

## Changes

### ContentEditor Component
- Added state for `urlInput` and `currentUrl` to manage URL loading
- Implemented UI controls for entering a URL and fetching content:
  - Fetch button uses standard URL fetch
  - Prerender button fetches prerendered plain text for better JS-heavy page support
- Added quick load buttons for connected CMS integrations (WordPress, Shopify) to open CMS modals
- Displays warning if fetched content is very short, suggesting prerender or manual paste
- Updates content, title, and HTML content based on fetched results

### Supabase Configuration
- Modified `prerender-fetch` function config to disable JWT verification, allowing unauthenticated browser calls

## Test plan
- [x] Load content from a valid URL using standard fetch
- [x] Load prerendered content from a JS-heavy page URL
- [x] Use quick load buttons to open CMS modals for WordPress and Shopify
- [x] Verify warning appears for short fetched content
- [x] Confirm toast notifications appear for success, warning, and error states
- [x] Ensure Supabase function works without JWT verification

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/32d6c0ce-5836-4200-b650-0b5a468e437b