### PR TITLE
Improve API response handling and normalization; Add schema draft upsert, schema preference UI, and citations panel in ContentEditor; Enhance competitor discovery filtering

### DIFF
--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -1,0 +1,37 @@
+name: Deploy Supabase Edge Functions
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - terragon/improve-ai-seo-workflows
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+
+      - name: Link project
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+        run: |
+          supabase link --project-ref "$SUPABASE_PROJECT_REF"
+
+      - name: Deploy Edge Functions
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: |
+          supabase functions deploy \
+            schema-generator \
+            schema-validator \
+            wordpress-integration \
+            shopify-integration \
+            prerender-fetch
+

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -681,7 +681,8 @@ export const apiService = {
             ...options
         })
     });
-    return result.data;
+    // Normalized apiCall returns the output payload directly
+    return result?.items ? result.items : result;
   },
 
   async getCMSContentItem(cmsType: 'wordpress' | 'shopify', itemId: number | string) {
@@ -694,7 +695,8 @@ export const apiService = {
               [idKey]: itemId
           })
       });
-      return result.data;
+      // Normalized apiCall returns the output payload directly
+      return result;
   },
 
   async updateCMSContentItem(

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -63,12 +63,20 @@ const apiCall = async (url: string, options: RequestInit, authRequired: boolean 
     console.log(`API response from ${url}:`, data);
     
     // Handle different response formats from edge functions
-    if (data.success === false) {
-      throw new Error(data.error?.message || 'API returned error');
+    if (typeof data?.success !== 'undefined') {
+      if (data.success === false) {
+        throw new Error(data.error?.message || 'API returned error');
+      }
+      // success: true — normalize common payload keys
+      // Prefer explicit payload properties, otherwise return the full object
+      if (typeof data.data !== 'undefined') return data.data;
+      if (typeof data.output !== 'undefined') return data.output;
+      if (typeof data.result !== 'undefined') return data.result;
+      return data;
     }
     
-    // Some functions return { success: true, data: ... }, others return direct data
-    return data.success ? data.data : data;
+    // No success flag — return parsed body as-is
+    return data;
   } catch (error) {
     console.error(`API call failed for ${url}:`, error);
     throw error;


### PR DESCRIPTION
## Summary
- Enhanced the `apiCall` function to better handle different API response formats
- Added normalization for common payload keys (`data`, `output`, `result`) when `success` is true
- Improved error handling for responses with `success: false`
- Ensured fallback to returning raw data when no `success` flag is present
- Added upsert of schema drafts with CMS item IDs after publishing content in `ContentEditor`
- Introduced schema preference UI with options to view and switch between inserted and auto-generated schemas
- Added citations panel in `ContentEditor` to manage, insert anchors, and insert references with rel="nofollow" option
- Added deployment workflow for Supabase Edge Functions
- Enhanced competitor discovery function with expanded blocklist, tightened relevance threshold, and adjusted scoring for niche competitors

## Changes

### API Service
- Updated `apiCall` in `src/services/api.ts`:
  - Checks if `success` property exists in the response
  - Throws an error if `success` is explicitly `false` with the provided error message
  - Normalizes the returned payload by preferring `data`, then `output`, then `result` keys if present
  - Returns the entire response object if none of the common keys are found
  - Returns raw response data if no `success` flag is present

### Content Editor
- Updated `src/components/ContentEditor.tsx`:
  - After publishing to WordPress or Shopify, upserts schema draft with new CMS item ID for future matches
  - Added schema preference pill UI showing current schema usage (inserted, auto-generate, or none)
  - Added buttons to view schema details and switch schema preference
  - Added citations panel UI to add, edit, remove sources, and insert anchors or references block with rel="nofollow" toggle
  - Added functions to save and load citations usage per user/project/context

### User Data Service
- Updated `src/services/userDataService.ts`:
  - Added methods to save and retrieve citations usage data

### Competitor Discovery
- Updated `supabase/functions/competitor-discovery/index.ts`:
  - Expanded blocklist of irrelevant domains
  - Increased relevance score threshold from 30 to 45
  - Adjusted scoring to penalize very high domain authority competitors unless aspirational

### CI/CD
- Added `.github/workflows/deploy-edge-functions.yml` to deploy Supabase Edge Functions on push or manual trigger

## Test plan
- [x] Verify API calls correctly throw errors on `success: false` responses
- [x] Confirm normalized data is returned for successful responses with different payload keys
- [x] Ensure raw data is returned when no `success` flag is present
- [x] Check console logs for proper debugging information on API responses and errors
- [x] Verify schema drafts are saved with correct CMS item IDs after publishing
- [x] Confirm schema preference UI displays and toggles correctly
- [x] Validate citations panel functionality: add/edit/remove sources, insert anchors, insert references block, rel="nofollow" toggle
- [x] Confirm citations usage is saved and loaded correctly
- [x] Validate deployment workflow triggers and deploys edge functions
- [x] Confirm competitor discovery filters and scoring adjustments behave as expected

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7485e9c3-fe4a-45a0-9bb4-05e6e2db9e0b
