### PR TITLE
fix: inline response helper in edge functions

### DIFF
--- a/supabase/functions/ai-sitemap/index.ts
+++ b/supabase/functions/ai-sitemap/index.ts
@@ -1,5 +1,5 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { ok, fail } from "../_shared/response.ts";
+import { ok, fail } from "./response.ts";
 
 // --- CORS Headers ---
 const corsHeaders = {

--- a/supabase/functions/ai-sitemap/response.ts
+++ b/supabase/functions/ai-sitemap/response.ts
@@ -1,0 +1,24 @@
+export function newRequestId() {
+  try {
+    // @ts-ignore Deno global
+    return crypto?.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+  } catch {
+    return `${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+  }
+}
+
+export function ok(data: any, meta?: Record<string, any>) {
+  const rid = newRequestId();
+  const body: any = { success: true, data, request_id: rid };
+  if (meta && typeof meta === 'object') body.meta = meta;
+  return body;
+}
+
+export function fail(message: string, code?: string, meta?: Record<string, any>) {
+  const rid = newRequestId();
+  const body: any = { success: false, error: { message }, request_id: rid };
+  if (code) body.error.code = code;
+  if (meta && typeof meta === 'object') body.meta = meta;
+  return body;
+}
+

--- a/supabase/functions/assistant-testbench/index.ts
+++ b/supabase/functions/assistant-testbench/index.ts
@@ -1,5 +1,5 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { ok, fail } from "../_shared/response.ts";
+import { ok, fail } from "./response.ts";
 
 // --- CORS Headers ---
 const corsHeaders = {

--- a/supabase/functions/assistant-testbench/response.ts
+++ b/supabase/functions/assistant-testbench/response.ts
@@ -1,0 +1,24 @@
+export function newRequestId() {
+  try {
+    // @ts-ignore Deno global
+    return crypto?.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+  } catch {
+    return `${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+  }
+}
+
+export function ok(data: any, meta?: Record<string, any>) {
+  const rid = newRequestId();
+  const body: any = { success: true, data, request_id: rid };
+  if (meta && typeof meta === 'object') body.meta = meta;
+  return body;
+}
+
+export function fail(message: string, code?: string, meta?: Record<string, any>) {
+  const rid = newRequestId();
+  const body: any = { success: false, error: { message }, request_id: rid };
+  if (code) body.error.code = code;
+  if (meta && typeof meta === 'object') body.meta = meta;
+  return body;
+}
+

--- a/supabase/functions/competitor-discovery/deno.json
+++ b/supabase/functions/competitor-discovery/deno.json
@@ -1,5 +1,0 @@
-{
-  "imports": {
-    "shared/": "../_shared/"
-  }
-}

--- a/supabase/functions/competitor-discovery/index.ts
+++ b/supabase/functions/competitor-discovery/index.ts
@@ -1,7 +1,7 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { createHmac } from "node:crypto";
 import { getDomain } from "https://esm.sh/tldts@6";
-import { ok, fail } from "../_shared/response.ts";
+import { ok, fail } from "./response.ts";
 // --- CORS Headers ---
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',

--- a/supabase/functions/competitor-discovery/response.ts
+++ b/supabase/functions/competitor-discovery/response.ts
@@ -1,0 +1,24 @@
+export function newRequestId() {
+  try {
+    // @ts-ignore Deno global
+    return crypto?.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+  } catch {
+    return `${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+  }
+}
+
+export function ok(data: any, meta?: Record<string, any>) {
+  const rid = newRequestId();
+  const body: any = { success: true, data, request_id: rid };
+  if (meta && typeof meta === 'object') body.meta = meta;
+  return body;
+}
+
+export function fail(message: string, code?: string, meta?: Record<string, any>) {
+  const rid = newRequestId();
+  const body: any = { success: false, error: { message }, request_id: rid };
+  if (code) body.error.code = code;
+  if (meta && typeof meta === 'object') body.meta = meta;
+  return body;
+}
+

--- a/supabase/functions/schema-batch-validator/index.ts
+++ b/supabase/functions/schema-batch-validator/index.ts
@@ -1,5 +1,5 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { ok, fail } from "../_shared/response.ts";
+import { ok, fail } from "./response.ts";
 
 // --- CORS Headers ---
 const corsHeaders = {

--- a/supabase/functions/schema-batch-validator/response.ts
+++ b/supabase/functions/schema-batch-validator/response.ts
@@ -1,0 +1,24 @@
+export function newRequestId() {
+  try {
+    // @ts-ignore Deno global
+    return crypto?.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+  } catch {
+    return `${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+  }
+}
+
+export function ok(data: any, meta?: Record<string, any>) {
+  const rid = newRequestId();
+  const body: any = { success: true, data, request_id: rid };
+  if (meta && typeof meta === 'object') body.meta = meta;
+  return body;
+}
+
+export function fail(message: string, code?: string, meta?: Record<string, any>) {
+  const rid = newRequestId();
+  const body: any = { success: false, error: { message }, request_id: rid };
+  if (code) body.error.code = code;
+  if (meta && typeof meta === 'object') body.meta = meta;
+  return body;
+}
+

--- a/supabase/functions/shopify-integration/deno.json
+++ b/supabase/functions/shopify-integration/deno.json
@@ -1,5 +1,0 @@
-{
-  "imports": {
-    "shared/": "../_shared/"
-  }
-}

--- a/supabase/functions/shopify-integration/index.ts
+++ b/supabase/functions/shopify-integration/index.ts
@@ -1,5 +1,5 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { ok, fail } from "../_shared/response.ts";
+import { ok, fail } from "./response.ts";
 // --- CORS Headers ---
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',

--- a/supabase/functions/shopify-integration/response.ts
+++ b/supabase/functions/shopify-integration/response.ts
@@ -1,0 +1,24 @@
+export function newRequestId() {
+  try {
+    // @ts-ignore Deno global
+    return crypto?.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+  } catch {
+    return `${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+  }
+}
+
+export function ok(data: any, meta?: Record<string, any>) {
+  const rid = newRequestId();
+  const body: any = { success: true, data, request_id: rid };
+  if (meta && typeof meta === 'object') body.meta = meta;
+  return body;
+}
+
+export function fail(message: string, code?: string, meta?: Record<string, any>) {
+  const rid = newRequestId();
+  const body: any = { success: false, error: { message }, request_id: rid };
+  if (code) body.error.code = code;
+  if (meta && typeof meta === 'object') body.meta = meta;
+  return body;
+}
+

--- a/supabase/functions/wordpress-integration/deno.json
+++ b/supabase/functions/wordpress-integration/deno.json
@@ -1,5 +1,0 @@
-{
-  "imports": {
-    "shared/": "../_shared/"
-  }
-}

--- a/supabase/functions/wordpress-integration/index.ts
+++ b/supabase/functions/wordpress-integration/index.ts
@@ -1,5 +1,5 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { ok, fail } from "../_shared/response.ts";
+import { ok, fail } from "./response.ts";
 // --- CORS Headers ---
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',

--- a/supabase/functions/wordpress-integration/response.ts
+++ b/supabase/functions/wordpress-integration/response.ts
@@ -1,0 +1,24 @@
+export function newRequestId() {
+  try {
+    // @ts-ignore Deno global
+    return crypto?.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+  } catch {
+    return `${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+  }
+}
+
+export function ok(data: any, meta?: Record<string, any>) {
+  const rid = newRequestId();
+  const body: any = { success: true, data, request_id: rid };
+  if (meta && typeof meta === 'object') body.meta = meta;
+  return body;
+}
+
+export function fail(message: string, code?: string, meta?: Record<string, any>) {
+  const rid = newRequestId();
+  const body: any = { success: false, error: { message }, request_id: rid };
+  if (code) body.error.code = code;
+  if (meta && typeof meta === 'object') body.meta = meta;
+  return body;
+}
+


### PR DESCRIPTION
## Summary
- include `response.ts` within each edge function directory
- load response helpers using local path to avoid deployment failures
- remove unused function-level import maps

## Testing
- `deno test supabase/functions/competitor-discovery/index.test.ts` *(fails: command not found: deno)*
- `curl -fsSL https://deno.land/install.sh | sh` *(fails: requested URL returned error: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f1054f888325ba0547fce359a489